### PR TITLE
Adds missing cities

### DIFF
--- a/cities.yml
+++ b/cities.yml
@@ -22238,3 +22238,18 @@ row5560:
   name: Xambioá
   state: TO
 
+row5561:
+  name: Aroeiras do Itaim
+  state: PI
+
+row5562:
+  name: Figueirão
+  state: MS
+
+row5563:
+  name: Ipiranga do Norte
+  state: MT
+
+row5564:
+  name: Itanhangá
+  state: MT


### PR DESCRIPTION
While iterating over the cities to add the IBGE's code, I found 4 missing cities.
I already confirmed and they are all valid.
This patch adds them.
